### PR TITLE
Ignore Static Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ dmypy.json
 
 *.jpg
 
+# Compiled Assets
+static


### PR DESCRIPTION
If you build the static files locally this will ignore the output folder.